### PR TITLE
feat: Rename PyPI package to sygaldry-cli and use main repo as registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ sygaldry provides essential tooling for AI engineers and researchers building pr
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python Version](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
-[![PyPI version](https://badge.fury.io/py/sygaldry.svg)](https://badge.fury.io/py/sygaldry)
+[![PyPI version](https://badge.fury.io/py/sygaldry-cli.svg)](https://badge.fury.io/py/sygaldry-cli)
 
 ## Mission
 
@@ -68,10 +68,10 @@ When you run `sygaldry add <component>`, the CLI:
 
 ```bash
 # Install the CLI
-pip install sygaldry
+pip install sygaldry-cli
 
 # Or with uv (recommended)
-uv pip install sygaldry
+uv pip install sygaldry-cli-cli
 ```
 
 ### Initialize Your Project

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -46,12 +46,12 @@ When you add a component:
 ## Installation
 
 ```bash
-pip install sygaldry
+pip install sygaldry-cli
 ```
 
 Or with uv (recommended):
 ```bash
-uv pip install sygaldry
+uv pip install sygaldry-cli-cli
 ```
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "sygaldry"
+name = "sygaldry-cli"
 version = "0.1.0"
 description = "Production-ready AI components that you can copy and paste into your apps"
 authors = [

--- a/src/sygaldry_cli/config_manager.py
+++ b/src/sygaldry_cli/config_manager.py
@@ -12,7 +12,7 @@ console = Console()
 
 CONFIG_ENV_VAR = "SYGALDRY_CONFIG_FILE"
 PROJECT_CONFIG_FILENAME = "sygaldry.json"
-DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/greyhaven-ai/sygaldry_registry/main/index.json"
+DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/greyhaven-ai/sygaldry/main/packages/sygaldry_registry/index.json"
 
 
 class ComponentPaths(BaseModel):

--- a/uv.lock
+++ b/uv.lock
@@ -496,148 +496,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sygaldry"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "httpx" },
-    { name = "platformdirs" },
-    { name = "pydantic" },
-    { name = "rich" },
-    { name = "typer" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "aiofiles" },
-    { name = "alembic" },
-    { name = "argcomplete" },
-    { name = "asyncpg" },
-    { name = "beautifulsoup4" },
-    { name = "deptry" },
-    { name = "duckduckgo-search" },
-    { name = "exa-py" },
-    { name = "firecrawl-py" },
-    { name = "fuzzywuzzy" },
-    { name = "gitpython" },
-    { name = "icecream" },
-    { name = "ipython" },
-    { name = "jsonpath-ng" },
-    { name = "lilypad-sdk" },
-    { name = "lxml" },
-    { name = "markdown" },
-    { name = "mirascope" },
-    { name = "mypy" },
-    { name = "pandas" },
-    { name = "psycopg2-binary" },
-    { name = "pyclean" },
-    { name = "pygithub" },
-    { name = "pypdf2" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "python-docx" },
-    { name = "python-frontmatter" },
-    { name = "python-levenshtein" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "ruff" },
-    { name = "sqlalchemy" },
-    { name = "youtube-transcript-api" },
-]
-test = [
-    { name = "coverage" },
-    { name = "hypothesis", extra = ["cli"] },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-datafiles" },
-    { name = "pytest-xdist" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "reportlab" },
-    { name = "ruff" },
-    { name = "types-aiofiles" },
-    { name = "types-markdown" },
-    { name = "types-pyyaml" },
-    { name = "types-requests" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiofiles", marker = "extra == 'dev'", specifier = ">=0.8.0" },
-    { name = "alembic", marker = "extra == 'dev'", specifier = ">=1.12.0" },
-    { name = "argcomplete", marker = "extra == 'dev'", specifier = ">=3.5.0,<4.0.0" },
-    { name = "asyncpg", marker = "extra == 'dev'", specifier = ">=0.29.0" },
-    { name = "beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12.0" },
-    { name = "coverage", marker = "extra == 'test'", specifier = ">=7.6.1,<8.0.0" },
-    { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.23.0,<1.0.0" },
-    { name = "duckduckgo-search", marker = "extra == 'dev'", specifier = ">=3.8.0" },
-    { name = "exa-py", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "firecrawl-py", marker = "extra == 'dev'", specifier = ">=0.0.1" },
-    { name = "fuzzywuzzy", marker = "extra == 'dev'", specifier = ">=0.18.0" },
-    { name = "gitpython", marker = "extra == 'dev'", specifier = ">=3.1.0" },
-    { name = "httpx", specifier = ">=0.27.0,<0.28.0" },
-    { name = "hypothesis", extras = ["cli"], marker = "extra == 'test'", specifier = ">=6.112.1,<7.0.0" },
-    { name = "icecream", marker = "extra == 'dev'", specifier = ">=2.1.3,<3.0.0" },
-    { name = "ipython", marker = "extra == 'dev'", specifier = ">=8.27.0,<9.0.0" },
-    { name = "jsonpath-ng", marker = "extra == 'dev'", specifier = ">=1.6.0" },
-    { name = "lilypad-sdk", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "lxml", marker = "extra == 'dev'", specifier = ">=4.9.0" },
-    { name = "markdown", marker = "extra == 'dev'", specifier = ">=3.5.0" },
-    { name = "mirascope", marker = "extra == 'dev'", specifier = ">=1.24.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.1,<2.0.0" },
-    { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.0.0" },
-    { name = "platformdirs", specifier = ">=4.0.0,<5.0.0" },
-    { name = "psycopg2-binary", marker = "extra == 'dev'", specifier = ">=2.9.0" },
-    { name = "pyclean", marker = "extra == 'dev'", specifier = ">=3.0.0,<4.0.0" },
-    { name = "pydantic", specifier = ">=2.5.0,<3.0.0" },
-    { name = "pygithub", marker = "extra == 'dev'", specifier = ">=2.1.0" },
-    { name = "pypdf2", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.4,<9.0.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3,<9.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.2,<1.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0,<1.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.1.1" },
-    { name = "pytest-datafiles", marker = "extra == 'test'", specifier = ">=3.0.0,<4.0.0" },
-    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.6.1,<4.0.0" },
-    { name = "python-docx", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "python-frontmatter", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "python-levenshtein", marker = "extra == 'dev'", specifier = ">=0.20.0" },
-    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "rich", specifier = ">=13.0.0,<14.0.0" },
-    { name = "rich", marker = "extra == 'dev'", specifier = ">=13.8.1,<14.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.5" },
-    { name = "sqlalchemy", marker = "extra == 'dev'", specifier = ">=2.0.0" },
-    { name = "typer", extras = ["all"], specifier = ">=0.12.3,<0.13.0" },
-    { name = "youtube-transcript-api", marker = "extra == 'dev'", specifier = ">=0.6.0" },
-]
-provides-extras = ["dev", "test"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy", specifier = ">=1.15.0" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-asyncio", specifier = ">=0.26.0" },
-    { name = "pytest-cov", specifier = ">=6.1.1" },
-    { name = "reportlab", specifier = ">=4.4.2" },
-    { name = "ruff", specifier = ">=0.11.6" },
-    { name = "types-aiofiles", specifier = ">=24.1.0.20250516" },
-    { name = "types-markdown", specifier = ">=3.8.0.20250415" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
-    { name = "types-requests", specifier = ">=2.32.0.20250515" },
-]
-
-[[package]]
 name = "fuzzywuzzy"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1948,6 +1806,148 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload_time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload_time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "sygaldry-cli"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "aiofiles" },
+    { name = "alembic" },
+    { name = "argcomplete" },
+    { name = "asyncpg" },
+    { name = "beautifulsoup4" },
+    { name = "deptry" },
+    { name = "duckduckgo-search" },
+    { name = "exa-py" },
+    { name = "firecrawl-py" },
+    { name = "fuzzywuzzy" },
+    { name = "gitpython" },
+    { name = "icecream" },
+    { name = "ipython" },
+    { name = "jsonpath-ng" },
+    { name = "lilypad-sdk" },
+    { name = "lxml" },
+    { name = "markdown" },
+    { name = "mirascope" },
+    { name = "mypy" },
+    { name = "pandas" },
+    { name = "psycopg2-binary" },
+    { name = "pyclean" },
+    { name = "pygithub" },
+    { name = "pypdf2" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "python-docx" },
+    { name = "python-frontmatter" },
+    { name = "python-levenshtein" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "ruff" },
+    { name = "sqlalchemy" },
+    { name = "youtube-transcript-api" },
+]
+test = [
+    { name = "coverage" },
+    { name = "hypothesis", extra = ["cli"] },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-datafiles" },
+    { name = "pytest-xdist" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "reportlab" },
+    { name = "ruff" },
+    { name = "types-aiofiles" },
+    { name = "types-markdown" },
+    { name = "types-pyyaml" },
+    { name = "types-requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiofiles", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "alembic", marker = "extra == 'dev'", specifier = ">=1.12.0" },
+    { name = "argcomplete", marker = "extra == 'dev'", specifier = ">=3.5.0,<4.0.0" },
+    { name = "asyncpg", marker = "extra == 'dev'", specifier = ">=0.29.0" },
+    { name = "beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12.0" },
+    { name = "coverage", marker = "extra == 'test'", specifier = ">=7.6.1,<8.0.0" },
+    { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.23.0,<1.0.0" },
+    { name = "duckduckgo-search", marker = "extra == 'dev'", specifier = ">=3.8.0" },
+    { name = "exa-py", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "firecrawl-py", marker = "extra == 'dev'", specifier = ">=0.0.1" },
+    { name = "fuzzywuzzy", marker = "extra == 'dev'", specifier = ">=0.18.0" },
+    { name = "gitpython", marker = "extra == 'dev'", specifier = ">=3.1.0" },
+    { name = "httpx", specifier = ">=0.27.0,<0.28.0" },
+    { name = "hypothesis", extras = ["cli"], marker = "extra == 'test'", specifier = ">=6.112.1,<7.0.0" },
+    { name = "icecream", marker = "extra == 'dev'", specifier = ">=2.1.3,<3.0.0" },
+    { name = "ipython", marker = "extra == 'dev'", specifier = ">=8.27.0,<9.0.0" },
+    { name = "jsonpath-ng", marker = "extra == 'dev'", specifier = ">=1.6.0" },
+    { name = "lilypad-sdk", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "lxml", marker = "extra == 'dev'", specifier = ">=4.9.0" },
+    { name = "markdown", marker = "extra == 'dev'", specifier = ">=3.5.0" },
+    { name = "mirascope", marker = "extra == 'dev'", specifier = ">=1.24.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.1,<2.0.0" },
+    { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.0.0" },
+    { name = "platformdirs", specifier = ">=4.0.0,<5.0.0" },
+    { name = "psycopg2-binary", marker = "extra == 'dev'", specifier = ">=2.9.0" },
+    { name = "pyclean", marker = "extra == 'dev'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "pydantic", specifier = ">=2.5.0,<3.0.0" },
+    { name = "pygithub", marker = "extra == 'dev'", specifier = ">=2.1.0" },
+    { name = "pypdf2", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3,<9.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.2,<1.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0,<1.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.1.1" },
+    { name = "pytest-datafiles", marker = "extra == 'test'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.6.1,<4.0.0" },
+    { name = "python-docx", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "python-frontmatter", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "python-levenshtein", marker = "extra == 'dev'", specifier = ">=0.20.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "rich", specifier = ">=13.0.0,<14.0.0" },
+    { name = "rich", marker = "extra == 'dev'", specifier = ">=13.8.1,<14.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.5" },
+    { name = "sqlalchemy", marker = "extra == 'dev'", specifier = ">=2.0.0" },
+    { name = "typer", extras = ["all"], specifier = ">=0.12.3,<0.13.0" },
+    { name = "youtube-transcript-api", marker = "extra == 'dev'", specifier = ">=0.6.0" },
+]
+provides-extras = ["dev", "test"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.15.0" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "reportlab", specifier = ">=4.4.2" },
+    { name = "ruff", specifier = ">=0.11.6" },
+    { name = "types-aiofiles", specifier = ">=24.1.0.20250516" },
+    { name = "types-markdown", specifier = ">=3.8.0.20250415" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
+    { name = "types-requests", specifier = ">=2.32.0.20250515" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Rename PyPI package from `sygaldry` to `sygaldry-cli` to better reflect its purpose
- Update registry URL to use the main repository instead of requiring a separate registry repo
- Update all documentation to reflect the new package name

## Changes
- Updated `pyproject.toml` to change package name to `sygaldry-cli`
- Updated installation instructions in README.md and README_PYPI.md
- Updated PyPI badge URL in README.md
- Modified default registry URL to point to `https://raw.githubusercontent.com/greyhaven-ai/sygaldry/main/packages/sygaldry_registry/index.json`

## Benefits
- Clearer package naming on PyPI
- Simplified deployment process (no separate registry repo needed)
- Single source of truth for both code and component registry

## Test plan
- [ ] Verify package builds correctly with new name
- [ ] Test installation from PyPI after publishing
- [ ] Confirm CLI can fetch components from new registry URL